### PR TITLE
[미션4] 동적 라우팅을 구현하라 #9

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -5,6 +5,7 @@ import { PATH } from './lib/const/path';
 import {
   SignInPage, SignUpPage, Component, Home,
 } from './ui/pages';
+import GugudanPage from './ui/pages/GugudanPage';
 
 const Router = () => (
   <Routes>
@@ -12,6 +13,7 @@ const Router = () => (
     <Route path={PATH.SIGN_IN} element={<SignInPage />} />
     <Route path={PATH.SIGN_UP} element={<SignUpPage />} />
     <Route path={PATH.COMPONENT} element={<Component />} />
+    <Route path={PATH.GUGUDAN} element={<GugudanPage />} />
   </Routes>
 );
 

--- a/src/lib/const/path.ts
+++ b/src/lib/const/path.ts
@@ -3,4 +3,5 @@ export const PATH = {
   SIGN_IN: '/signin',
   SIGN_UP: '/signup',
   COMPONENT: '/component',
+  GUGUDAN: '/gugudan/:id',
 };

--- a/src/ui/pages/GugudanPage.tsx
+++ b/src/ui/pages/GugudanPage.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useParams } from 'react-router';
+
+const GugudanPage = () => {
+  const params = useParams();
+  const { id } = params;
+
+  return (
+    <>
+      구구단 페이지 id: {id}
+    </>
+  );
+};
+
+export default GugudanPage;


### PR DESCRIPTION
## 구현 사항
- [x] GugudanPage 파일을 pages 폴더 하위에 추가했습니다.
- [x] /gugudan/{id} 형식의 라우트를 추가했습니다.
- [x] /gugudan/{id} 페이지로 접근시 GugudanPage가 렌더링 되도록 구현했습니다.
- [x] 동적라우팅을 통해 {id} 값이 페이지에 표시 되도록 구현했습니다.

<br/>

## 이미지

<img width="346" alt="스크린샷 2022-12-27 오전 1 50 54" src="https://user-images.githubusercontent.com/97431021/209569170-1b069ee6-63e5-4526-a495-6fe871eb7b7a.png">
